### PR TITLE
Use python3 on hashbang line

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py}]
+charset = utf-8
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# help pages
+[*.page]
+indent_style = space
+indent_size = 4

--- a/hamster.1m.py
+++ b/hamster.1m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 from enum import Enum, auto
@@ -8,11 +8,11 @@ class Version(Enum):
 
 
 ##### Custommization
-# Shall we use an icon instead of the current activity in the 
+# Shall we use an icon instead of the current activity in the
 USE_ICON=False
 
 # Choose your hamster version
-# ⚠ hamster 1.04 doesn't leave when the window to add new activity 
+# ⚠ hamster 1.04 doesn't leave when the window to add new activity
 #   is closed and as such it will leave many backround processes.
 HAMSTER_VERSION  = Version.TWO
 # HAMSTER_VERSION : Version.ONE
@@ -109,7 +109,7 @@ class Hamster():
         if self.active:
             txt = " ".join(self.current_full.split(',')[0].split()[2:])
         else:
-            txt = self.current_activity 
+            txt = self.current_activity
         spaces = " " * (max(1, MENU_WIDTH-len(txt)))
         print(f"{begin}{txt}{spaces}{end}")
         if self.active:
@@ -141,7 +141,7 @@ class Hamster():
                 if l.startswith("------"):
                     break
             # Remove "in" de "min", remove empty hours and minutes, and spaces
-            fulltotal = ",".join(map(lambda x: x[:-2] 
+            fulltotal = ",".join(map(lambda x: x[:-2]
                                        .replace(" 0h","")\
                                        .replace(" 0m","")\
                                        .replace(" ",""),


### PR DESCRIPTION
On my system (ubuntu 19.04), /usr/bin/python is still python2 and this program requires /usr/bin/python3.

Also added a .editorconfig file (to help avoid differences in trailing spaces in the future).