### PR TITLE
Add ranking of recent activities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 all:
-	cp hamster.1m.py ~/.config/argos/
+	cp hamster.1m.py ~/.config/argos/hamster.1m+.py

--- a/hamster.1m.py
+++ b/hamster.1m.py
@@ -29,7 +29,7 @@ HAMSTER_VERSION  = Version.TWO
 # How many days to look back in the past in order to get past activities
 DAYS = 14
 # Whether to rank recent activities by age and frequency
-AGE_FREQUENCY_RANKING = True
+AGE_FREQUENCY_RANKING = False
 # Whether to include the description for recent activities
 USE_DESCRIPTION = False
 
@@ -92,8 +92,10 @@ def recent_activities():
             rank[fact] += DAYS - int((today - start).days)
         else:
             rank[fact] = 1
-    return [k for (v, k) in reversed(sorted(((v, k) for (k, v) in rank.items())))]
-
+    if AGE_FREQUENCY_RANKING:
+        return [k for (v, k) in reversed(sorted(((v, k) for (k, v) in rank.items())))]
+    else:
+        return list(sorted(rank))
 
 @dataclass
 class Hamster():


### PR DESCRIPTION
Added option to rank recent activities by age-frequency as in Hamster.

Also a few other tweaks:
- rename script with '+' to force refresh on menu selection
- show activity without category but with time in header
- add option to avoid using "description" field (in part because it could
  be lengthy, in part because new activities will have new descriptions)
- remove functools.lru_cache because function called just once
- move imports to top of file